### PR TITLE
fix<composer>: change php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": "^5.6.0",
         "symfony/symfony": "3.1.*",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",


### PR DESCRIPTION
Because of Scrutinizer error:
doctrine/data-fixtures v1.2.1 requires php ^5.6 || ^7.0 -> your PHP version (5.5.25) does not satisfy that requirement.